### PR TITLE
fix: typo on has_required_permissions method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ Define & use custom permissions based on FastAPI Dependency framework:
 
     class TeapotUserAgentPermission(BasePermission):
 
-        def has_required_permisions(self, request: Request) -> bool:
+        def has_required_permissions(self, request: Request) -> bool:
             return request.headers.get('User-Agent') == "Teapot v1.0"
 
     app = FastAPI()

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -69,7 +69,7 @@ Define & use custom permissions based on FastAPI Dependency framework:
 
     class TeapotUserAgentPermission(BasePermission):
 
-        def has_required_permisions(self, request: Request) -> bool:
+        def has_required_permissions(self, request: Request) -> bool:
             return request.headers.get('User-Agent') == "Teapot v1.0"
 
     app = FastAPI()

--- a/fastapi_contrib/auth/permissions.py
+++ b/fastapi_contrib/auth/permissions.py
@@ -26,5 +26,5 @@ class IsAuthenticated(BasePermission):
     status_code = status.HTTP_401_UNAUTHORIZED
     error_code = status.HTTP_401_UNAUTHORIZED
 
-    def has_required_permisions(self, request: Request) -> bool:
+    def has_required_permissions(self, request: Request) -> bool:
         return request.user is not None

--- a/fastapi_contrib/permissions.py
+++ b/fastapi_contrib/permissions.py
@@ -12,7 +12,7 @@ class BasePermission(ABC):
 
     Defines basic error message, status & error codes.
 
-    Upon initialization, calls abstract method  `has_required_permisions`
+    Upon initialization, calls abstract method  `has_required_permissions`
     which will be specific to concrete implementation of Permission class.
 
     You would write your permissions like this:
@@ -21,7 +21,7 @@ class BasePermission(ABC):
 
         class TeapotUserAgentPermission(BasePermission):
 
-            def has_required_permisions(self, request: Request) -> bool:
+            def has_required_permissions(self, request: Request) -> bool:
                 return request.headers.get('User-Agent') == "Teapot v1.0"
 
     """
@@ -30,11 +30,11 @@ class BasePermission(ABC):
     error_code = status.HTTP_403_FORBIDDEN
 
     @abstractmethod
-    def has_required_permisions(self, request: Request) -> bool:
+    def has_required_permissions(self, request: Request) -> bool:
         ...
 
     def __init__(self, request: Request):
-        if not self.has_required_permisions(request):
+        if not self.has_required_permissions(request):
             raise HTTPException(
                 status_code=self.status_code,
                 detail=self.error_msg,

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -29,8 +29,8 @@ def test_base_permission_has_required_permission(dumb_request):
 
     class NewPermission(BasePermission):
 
-        def has_required_permisions(self, request: Request) -> bool:
-            return super().has_required_permisions(request=request)
+        def has_required_permissions(self, request: Request) -> bool:
+            return super().has_required_permissions(request=request)
 
     with pytest.raises(HTTPException):
         NewPermission(request=dumb_request)
@@ -39,7 +39,7 @@ def test_base_permission_has_required_permission(dumb_request):
 def test_base_permission_no_permission_raises_403(dumb_request):
     class FailPermission(BasePermission):
 
-        def has_required_permisions(self, request: Request) -> bool:
+        def has_required_permissions(self, request: Request) -> bool:
             return False
 
     with pytest.raises(HTTPException) as excinfo:
@@ -52,7 +52,7 @@ def test_base_permission_no_permission_raises_403(dumb_request):
 def test_base_permission_has_permission_not_raises(dumb_request):
     class AllowPermission(BasePermission):
 
-        def has_required_permisions(self, request: Request) -> bool:
+        def has_required_permissions(self, request: Request) -> bool:
             return True
 
     permission = AllowPermission(request=dumb_request)
@@ -63,12 +63,12 @@ def test_base_permission_has_permission_not_raises(dumb_request):
 def test_permissions_dependency_as_class(dumb_request):
     class FailPermission(BasePermission):
 
-        def has_required_permisions(self, request: Request) -> bool:
+        def has_required_permissions(self, request: Request) -> bool:
             return False
 
     class AllowPermission(BasePermission):
 
-        def has_required_permisions(self, request: Request) -> bool:
+        def has_required_permissions(self, request: Request) -> bool:
             return True
 
     dependency = PermissionsDependency(permissions_classes=[AllowPermission])


### PR DESCRIPTION
I changed the name cause of typo. I will not be able to run test with tox in local, It seems to be an issue before my changes.