### PR TITLE
models can be now inspected as a package as well

### DIFF
--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -244,7 +244,7 @@ def test_exception_handler_when_choice_invalid():
         assert response["message"] == "Validation error."
         assert response["fields"] == [
             {
-                "message": "One or more values provided are not valid.",
+                "message": "Value is not a valid enumeration member; permitted: 'a', 'b', 'c'.",
                 "name": "kind",
                 "error_code": 400,
             }
@@ -262,7 +262,7 @@ def test_exception_handler_when_one_of_multi_choice_invalid():
         assert response["message"] == "Validation error."
         assert response["fields"] == [
             {
-                "message": "One or more values provided are not valid.",
+                "message": "Value is not a valid enumeration member; permitted: 'a', 'b', 'c'.",
                 "name": "multi",
                 "error_code": 400,
             }
@@ -280,7 +280,7 @@ def test_exception_handler_when_choice_default_and_received_invalid():
         assert response["message"] == "Validation error."
         assert response["fields"] == [
             {
-                "message": "One or more values provided are not valid.",
+                "message": "Value is not a valid enumeration member; permitted: 'a', 'b', 'c'.",
                 "name": "kind",
                 "error_code": 400,
             }
@@ -300,7 +300,7 @@ def test_exception_handler_when_choice_default_and_received_invalid():
         assert response["message"] == "Validation error."
         assert response["fields"] == [
             {
-                "message": "One or more values provided are not valid.",
+                "message": "Value is not a valid enumeration member; permitted: 'a', 'b', 'c'.",
                 "name": "kind",
                 "error_code": 400,
             },


### PR DESCRIPTION
MongoDBModels now can be created in different files in **models/** package as well as in a single **models.py** file.
To use the package-based models one will need to create **models/** directory with an **__init__.py** file in it which should import all necessary MongoDBModels. It is convenient when your model classes take too many code lines.